### PR TITLE
CI: update steampipe URL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Install Steampipe
         run: |
-          sudo /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/turbot/steampipe/HEAD/install.sh)"
+          sudo /bin/sh -c "$(curl -fsSL https://steampipe.io/install/steampipe.sh)"
           steampipe --version
           steampipe plugin install github
           steampipe plugin install net


### PR DESCRIPTION
This morning, I noticed the Pathogen status page was showing

> Generated at Wed Mar 06 2024 08:08:16 GMT-0800 (Pacific Standard Time).

The CI job had been failing with a 404 since then, which was due to the install.sh script being moved.¹

This commit updates the install step to use the official steampipe.io URL from their download page.²

¹ https://github.com/turbot/steampipe/commit/f7a78ec03265e7a810252747278dde21fcfd9c87 
² https://steampipe.io/downloads?install=linux

## Related issue(s)

Resolves #3 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
