### PR TITLE
CI: add timeout-minutes to `make` step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
       - run: make
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Timeout the this step as a work-around for https://github.com/nextstrain/status/issues/5
+        timeout-minutes: 10
 
       - if: always()
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Time out the step after 10 minutes to work around
https://github.com/nextstrain/status/issues/5

10 minutes seems reasonable since the entire workflow has been able to complete in less than 4 minutes.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Timeout worked as expected](https://github.com/nextstrain/status/actions/runs/8746515320)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
