### PR TITLE
Include zika GH Action workflow

### DIFF
--- a/pathogen-workflows.sql
+++ b/pathogen-workflows.sql
@@ -85,7 +85,15 @@ workflow as materialized (
             join github_workflow using (repository_full_name, id)
 
     where
-            workflow_file_content_json @@ '$.jobs.*.uses starts with "nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@"'
+            (workflow_file_content_json @@ '$.jobs.*.uses starts with "nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@"'
+                /* Temporary(?) workaround to include zika's ingest-to-phylogenetic workflow
+                 * We may pursue other methods in the future to include workflows that are not
+                 * directly using pathogen-repo-build.yaml.
+                 *  -Jover, 23 April 2024
+                 *
+                 * <https://github.com/nextstrain/status/issues/12>
+                 */
+                or path = '.github/workflows/ingest-to-phylogenetic.yaml')
         and name != 'CI'
 ),
 


### PR DESCRIPTION
## Description of proposed changes

Temporary(?) workaround to include zika's ingest-to-phylogenetic.yaml workflow which uses nested reusable workflows and isn't directly using the pathogen-repo-build workflow.

## Related issue(s)

Related to #12 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
