### PR TITLE
CI: Never regenerate favicon-*.svg from source

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: 16
 
-      - run: make
+      - run: make --assume-old=favicon.svg --assume-old="favicon-[layer].svg.py"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Timeout the this step as a work-around for https://github.com/nextstrain/status/issues/5


### PR DESCRIPTION
While it may be useful to regenerate them in development—it certainly was for me!—doing so in CI doesn't work because Inkscape isn't installed.  We could install Inkscape, but why bother?  The generated copies that are checked in to source control can be used as-is.

Suggested by @joverlee521 during troubleshooting¹ why CI sometimes failed: it was sometimes trying to regenerate these files because sometimes (it seems?) the input mtimes were newer than the output mtimes.

¹ <https://github.com/nextstrain/status/pull/29#issuecomment-2474677671>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
