### PR TITLE
Indicate non-underlined links with underlines on hover

### DIFF
--- a/pathogen-workflows.css
+++ b/pathogen-workflows.css
@@ -54,6 +54,9 @@ nav[aria-labelledby="layout-toggle"] {
 h2 > a:first-child {
   color: inherit;
   text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 h2 > a[href^="#"] {
@@ -67,6 +70,9 @@ h3 {
 h3 > a:first-child {
   color: inherit;
   text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 h3 > span {
   font-size: small;


### PR DESCRIPTION
The underline is such a universal hint that a thing is clickable.  It also clearly demarcates the extent of the link, which is helpful for adjacent or nearly adjacent links that go to different places.

While the underline feels too noisy to keep always present for these links, showing it on hover seems like a good compromise.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
