### PR TITLE
Indicate in nav if any of a pathogen's most recent workflow runs have failed

### DIFF
--- a/pathogen-workflows.css
+++ b/pathogen-workflows.css
@@ -32,6 +32,14 @@ nav[aria-label="repo-list"] ul li {
 nav[aria-label="repo-list"] ul li:not(:last-of-type) {
   padding-right: 1rem;
 }
+nav[aria-label="repo-list"] ul li .indicator {
+  text-decoration: white underline;
+}
+nav[aria-label="repo-list"] ul li .indicator.failure {
+  color: var(--color-failure);
+  position: relative;
+  top: 1px;
+}
 
 nav[aria-labelledby="layout-toggle"] {
   position: absolute;

--- a/pathogen-workflows.html.js
+++ b/pathogen-workflows.html.js
@@ -54,10 +54,16 @@ process.stdout.write(String(html`
       <nav aria-label="repo-list">
         <ul>
         ${
-          runsByRepoAndWorkflow.map(([repository_full_name,]) => html`
+          runsByRepoAndWorkflow.map(([repository_full_name, workflows]) => html`
             <li>
               <a href="#${repoShortName(repository_full_name)}">
-                ${repoShortName(repository_full_name)}
+                ${
+                  workflows
+                    .map(([, runs]) => runs[0].conclusion ?? runs[0].status)
+                    .some(x => x === "failure")
+                  ? html`<span class="indicator failure">${indicator({conclusion: "failure"})} </span>`
+                  : ""
+                }${repoShortName(repository_full_name)}
               </a>
             </li>
           `)


### PR DESCRIPTION
Helps quickly jump to the failing pathogen.  For example, if you notice the favicon indicates failure and want to go see what's up, you don't have to scroll thru the page to find the failure(s).

Other conclusion/status indicators are not shown in nav because it seemed too noisy and not notable enough.

![image](https://github.com/user-attachments/assets/b69cf3a1-dcf6-4a1d-bca0-b031208939fd)


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
