### PR TITLE
Gracefully handle being offline

### DIFF
--- a/pathogen-workflows.css
+++ b/pathogen-workflows.css
@@ -12,6 +12,9 @@
 :root.inhibit-transitions * {
   transition: none !important;
 }
+:root:not(.offline) .display-offline-only {
+  display: none !important;
+}
 
 body {
   font-family: sans-serif;
@@ -53,6 +56,17 @@ nav[aria-labelledby="layout-toggle"] {
   pointer-events: none;
   color: inherit;
   text-decoration: none;
+}
+
+.offline-warning {
+  background: orangered;
+  color: seashell;
+  padding: 1em;
+  border: 2px solid black;
+
+  position: sticky;
+  top: -2px;
+  z-index: 3;
 }
 
 .generated-at {

--- a/pathogen-workflows.html.js
+++ b/pathogen-workflows.html.js
@@ -75,6 +75,9 @@ process.stdout.write(String(html`
         <a href="?">compact</a>
         / <a href="?time-relative">time-relative</a>
       </nav>
+      <p class="display-offline-only offline-warning">
+        You’re offline.  Automatic refresh is paused and information may be stale.
+      </p>
       <p class="generated-at">
         Generated at <time datetime="${generatedAt}">${generatedAt}</time>
         by <a href="https://github.com/nextstrain/status">nextstrain/status</a>

--- a/pathogen-workflows.js
+++ b/pathogen-workflows.js
@@ -13,6 +13,11 @@
 const REFRESH_SECONDS = 60; // seconds
 
 function refreshIfAppropriate() {
+  if (!navigator.onLine) {
+    console.log("Offline… delaying refresh for another minute");
+    setTimeout(refreshIfAppropriate, REFRESH_SECONDS * 1000);
+    return;
+  }
   if (document.querySelectorAll("details[open]").length) {
     console.log("<details> are open… delaying refresh for another minute");
     setTimeout(refreshIfAppropriate, REFRESH_SECONDS * 1000);
@@ -194,6 +199,17 @@ document.addEventListener("keydown", event => {
 function queryPath(path, element = document) {
   return document.evaluate(path, element, null, XPathResult.FIRST_ORDERED_NODE_TYPE)?.singleNodeValue;
 }
+
+
+/* Reflect offline status for CSS.
+ */
+function updateOfflineStatus() {
+  document.querySelector(":root").classList.toggle("offline", !navigator.onLine);
+}
+
+updateOfflineStatus();
+window.addEventListener("online",  updateOfflineStatus);
+window.addEventListener("offline", updateOfflineStatus);
 
 
 /* Remove transition inhibition a short time after we're all done.


### PR DESCRIPTION
Inhibit the automatic refresh when offline to avoid triggering a "this site cannot be loaded" error page in the browser.  That's game over for us: once it happens we're unloaded and cannot recover with a subsequent refresh.

Display a prominent message when offline to avoid misleading a viewer who may not realize they're offline and refreshes aren't happening. This covers about the only useful case of the browser error page.

Firefox has a "work offline" mode which is useful for testing this, but the setting can also be flipped other ways (and in other browsers).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
