### PR TITLE
Warn about page staleness, e.g. due to updates failing to happen

### DIFF
--- a/pathogen-workflows.css
+++ b/pathogen-workflows.css
@@ -12,9 +12,6 @@
 :root.inhibit-transitions * {
   transition: none !important;
 }
-:root:not(.offline) .display-offline-only {
-  display: none !important;
-}
 
 body {
   font-family: sans-serif;
@@ -58,7 +55,7 @@ nav[aria-labelledby="layout-toggle"] {
   text-decoration: none;
 }
 
-.offline-warning {
+#offline-warning {
   background: orangered;
   color: seashell;
   padding: 1em;
@@ -69,7 +66,10 @@ nav[aria-labelledby="layout-toggle"] {
   z-index: 3;
 }
 
-.generated-at {
+#offline-warning { display: none }
+:root.offline #offline-warning { display: block }
+
+#generated-at {
   font-size: small;
 }
 

--- a/pathogen-workflows.css
+++ b/pathogen-workflows.css
@@ -55,10 +55,10 @@ nav[aria-labelledby="layout-toggle"] {
   text-decoration: none;
 }
 
-#offline-warning {
+#warnings {
   background: orangered;
   color: seashell;
-  padding: 1em;
+  padding: 0 1em;
   border: 2px solid black;
 
   position: sticky;
@@ -66,8 +66,9 @@ nav[aria-labelledby="layout-toggle"] {
   z-index: 3;
 }
 
-#offline-warning { display: none }
-:root.offline #offline-warning { display: block }
+#warnings, #offline-warning, #stale-warning { display: none }
+:root.offline { #warnings, #offline-warning { display: block } }
+:root.stale   { #warnings, #stale-warning   { display: block } }
 
 #generated-at {
   font-size: small;

--- a/pathogen-workflows.html.js
+++ b/pathogen-workflows.html.js
@@ -75,9 +75,16 @@ process.stdout.write(String(html`
         <a href="?">compact</a>
         / <a href="?time-relative">time-relative</a>
       </nav>
-      <p id="offline-warning">
-        You’re offline.  Automatic refresh is paused and information may be stale.
-      </p>
+      <div id="warnings">
+        <p id="offline-warning">
+          You’re offline.  Automatic refresh is paused and information may be stale.
+        </p>
+        <p id="stale-warning" data-stale-threshold="PT30M">
+          Page was generated
+          <time datetime="${generatedAt}" data-relative>more than 30 minutes ago</time>.
+          Information may be stale.
+        </p>
+      </div>
       <p id="generated-at">
         Generated at <time datetime="${generatedAt}">${generatedAt}</time>
         by <a href="https://github.com/nextstrain/status">nextstrain/status</a>

--- a/pathogen-workflows.html.js
+++ b/pathogen-workflows.html.js
@@ -75,10 +75,10 @@ process.stdout.write(String(html`
         <a href="?">compact</a>
         / <a href="?time-relative">time-relative</a>
       </nav>
-      <p class="display-offline-only offline-warning">
+      <p id="offline-warning">
         You’re offline.  Automatic refresh is paused and information may be stale.
       </p>
-      <p class="generated-at">
+      <p id="generated-at">
         Generated at <time datetime="${generatedAt}">${generatedAt}</time>
         by <a href="https://github.com/nextstrain/status">nextstrain/status</a>
         for repos using our shared <a href="https://github.com/nextstrain/.github/blob/HEAD/.github/workflows/pathogen-repo-build.yaml"><code>pathogen-repo-build.yaml</code> workflow</a>.

--- a/pathogen-workflows.js
+++ b/pathogen-workflows.js
@@ -37,7 +37,7 @@ setTimeout(refreshIfAppropriate, REFRESH_SECONDS * 1000);
  * Do this early on so that values are available soon after initial page load
  * and definitely before we set data-* attributes from query params below.
  */
-const now = luxon.DateTime.now().endOf("day");
+const endOfToday = luxon.DateTime.now().endOf("day");
 
 for (const ol of document.getElementsByTagName("ol")) {
   let previousDaysAgo = null;
@@ -48,7 +48,7 @@ for (const ol of document.getElementsByTagName("ol")) {
     const run = JSON.parse(li.dataset.run);
 
     const createdAt = luxon.DateTime.fromISO(run.created_at).endOf("day");
-    const daysAgo = now.diff(createdAt, "days").days;
+    const daysAgo = endOfToday.diff(createdAt, "days").days;
 
     if (previousDaysAgo === daysAgo) {
       runOfTheDay++;


### PR DESCRIPTION
No updates in this case might be that periodic refreshing is paused (e.g. because you have a `<details>` element open and maybe you don't realize it) or that periodic regeneration of the page is not happening (e.g. scheduled jobs are failing). Either way, it's good to call out that the time of generation is now older than expected. 30 minutes seems like a reasonable threshold for now given the usual update cadence of this page and the workflows it's showing.

Combines the staleness warning with the offline warning, if either is visible, so that there's just one (orange)red warning box at the top of the page instead of two or something.

![image](https://github.com/user-attachments/assets/540c037b-8054-4549-8e67-58220144be04)
