### PR TITLE
Correctly sort runs by created_at (descending) as intended

### DIFF
--- a/pathogen-workflows.html.js
+++ b/pathogen-workflows.html.js
@@ -24,7 +24,7 @@ const runsByRepoAndWorkflow =
       workflowRuns,
       d => d.repository_full_name.toLowerCase(),
       d => d.workflow_name.toLowerCase(),
-      d => -d.created_at,
+      d => -(new Date(d.created_at)),
       d => -d.id),
     d => d.repository_full_name,
     d => d.workflow_name );

--- a/pathogen-workflows.js
+++ b/pathogen-workflows.js
@@ -50,6 +50,7 @@ for (const ol of document.getElementsByTagName("ol")) {
     const createdAt = luxon.DateTime.fromISO(run.created_at).endOf("day");
     const daysAgo = endOfToday.diff(createdAt, "days").days;
 
+    // This relies on the run <li>'s being sorted by created_at.
     if (previousDaysAgo === daysAgo) {
       runOfTheDay++;
     } else {


### PR DESCRIPTION
created_at is an ISO 8601 timestamp, not an integer (i.e. Unix epoch time), so applying the unary negation operator to it resulted in a bunch of NaNs.  These were ignored by sort() and so the reverse chronological order we saw in practice was based solely on run ids.  Whoops!  Convert created_at to an epoch time for sorting.

I noticed this due to a layout bug where two runs occupied the same space in the time-relative layout.  That was because the day transition detection in that layout mode assumes (requires) a correct ordering by created_at when the ids are not sufficient to do so (e.g. because of a re-run attempt a few days later when another separate run also exists on that day).  I knew of this assumption/requirement but figured it warranted explicitly commenting on too.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
