### PR TITLE
CI: add `timeout-minutes` to publish job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Timeout to prevent publish job from holding up updates
+    # <https://github.com/nextstrain/status/issues/42>
+    timeout-minutes: 1
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description of proposed changes

Prevent publish jobs stuck in limbo from holding up updates. Setting to 1 minute since the publish job usually takes ~10s.

Resolves https://github.com/nextstrain/status/issues/42

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
