### PR TITLE
Avoid negative durations for currently running jobs started _after_ our transaction…

### DIFF
--- a/pathogen-workflows.sql
+++ b/pathogen-workflows.sql
@@ -195,7 +195,7 @@ run_last_attempt as materialized (
         run.status,
         case when run.conclusion is not null
             then run.updated_at - run.created_at
-            else current_timestamp(0) - run.created_at
+            else date_trunc('second', statement_timestamp()) - run.created_at
         end                             as duration,
         run.event,
         run.head_sha                    as commit_id,
@@ -294,7 +294,7 @@ attempt as materialized (
         run.status,
         case when run.conclusion is not null
             then run.updated_at - run.created_at
-            else current_timestamp(0) - run.created_at
+            else date_trunc('second', statement_timestamp()) - run.created_at
         end                             as duration,
         run.event,
         run.head_sha                    as commit_id,


### PR DESCRIPTION
…but _before_ this select statement which fetches from the GitHub API.

Compute durations for such jobs from the statement start time instead, which probably has the same race condition due to the nature of interacting with someone else's API, but the window of time of the race should be much much smaller.

Resolves: <https://github.com/nextstrain/status/issues/44>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
