### PR TITLE
CI: extend timeout to 15min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Timeout the this step as a work-around for https://github.com/nextstrain/status/issues/5
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       - if: always()
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION

## Description of proposed changes

The jobs have been hitting the 10min timeout more frequently, so bumping to 15min to see if it's enough to give us some more time as part of <https://github.com/nextstrain/status/issues/48>.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
